### PR TITLE
Add support for Scarlet & Violet sets

### DIFF
--- a/script.js
+++ b/script.js
@@ -97,7 +97,9 @@ var setIdTranslations = {
     'p6': 'pop6',
     'p7': 'pop7',
     'p8': 'pop8',
-    'p9': 'pop9'
+    'p9': 'pop9',
+    'svi': 'sv1',
+    'pal': 'sv2'
 }
 
 var ptcgoCodeTranslations = {


### PR DESCRIPTION
Importing a decklist containing SV1 and PAL cards from limitless wasn't working. Adding the proper set mapping fixes the import from clipboard.

This PR was tested locally!